### PR TITLE
Raspi logging singelton pattern

### DIFF
--- a/Drone/dwm1000_control/inc/ws_logger.hpp
+++ b/Drone/dwm1000_control/inc/ws_logger.hpp
@@ -8,6 +8,11 @@
 #include <string>
 #include <thread>
 
+
+/* Helper Macro to call global logger */
+#define WS_LOG(fmt, ...) \
+    WSLogger::get_instance().log("[%s:%d] " fmt, __FILE__, __LINE__, ##__VA_ARGS__)
+
 enum Logger_State 
 {
     CONNECTED,
@@ -17,7 +22,15 @@ enum Logger_State
 
 class WSLogger {
     public:
-        WSLogger(const char* server_address, uint16_t port, uint16_t id);
+
+        /**
+         * @brief Returns the singleton instance of WSLogger.
+         * 
+         * Ensures that only one instance of WSLogger exists througout the application. Globally.
+         * 
+         * @return WSLogger& - Reference to the global singleton instance.
+         */
+        static WSLogger& get_instance(const char* server_address, uint16_t port, uint16_t id);
         
         /* put a message into the output queue */
         void log(const char* message, ...);
@@ -25,6 +38,10 @@ class WSLogger {
         ~WSLogger();
         
     private:
+
+        /* Make Constructor Private */
+        WSLogger(const char* server_address, uint16_t port, uint16_t id);
+
         /**
          * Puts a message and a type encoded in JSON format into the sending queue.
          * 

--- a/Drone/dwm1000_control/inc/ws_logger.hpp
+++ b/Drone/dwm1000_control/inc/ws_logger.hpp
@@ -31,6 +31,11 @@ class WSLogger {
          * @return WSLogger& - Reference to the global singleton instance.
          */
         static WSLogger& get_instance(const char* server_address, uint16_t port, uint16_t id);
+
+        /**
+         * @brief Lazy initialization of the WSLogger instance.
+         */
+        static WSLogger& get_instance();
         
         /* put a message into the output queue */
         void log(const char* message, ...);

--- a/Drone/dwm1000_control/src/ws_logger.cpp
+++ b/Drone/dwm1000_control/src/ws_logger.cpp
@@ -7,6 +7,21 @@
 int WSLogger::send_len = 0;
 char* WSLogger::send_buffer = nullptr;
 
+WSLogger& WSLogger::get_instance(const char* server_address, uint16_t port, uint16_t id)
+{
+    static WSLogger* instance = nullptr;
+
+    if (!instance) {
+        if (!server_address || port == 0) {
+            fprintf(stderr, "[WSLogger] Invalid server address or port\n");
+            fprintf(stderr, "[WSLogger] must be initialized with parameters at first call.\n");
+        }
+        instance = new WSLogger(server_address, port, id);
+    }
+
+    return *instance;
+}
+
 WSLogger::WSLogger(const char* server_address, uint16_t port, uint16_t id)
 {
     this->id = id;
@@ -154,6 +169,7 @@ int WSLogger::callback(struct lws* wsi, enum lws_callback_reasons reason, void* 
     }
     return 0;
 }
+
 void WSLogger::log(const char* message, ...)
 {
     va_list args;
@@ -184,6 +200,7 @@ void WSLogger::sendID()
     snprintf(hex_id, sizeof(hex_id), "0x%04X", id);  // z. B. "0x1A2B"
     queue("id", hex_id);
 }
+
 bool WSLogger::connect(const char* address, int port, const char* path)
 {
     struct lws_context_creation_info info = {};

--- a/Drone/dwm1000_control/src/ws_logger.cpp
+++ b/Drone/dwm1000_control/src/ws_logger.cpp
@@ -9,6 +9,7 @@ char* WSLogger::send_buffer = nullptr;
 
 WSLogger& WSLogger::get_instance(const char* server_address, uint16_t port, uint16_t id)
 {
+    /* Static pointer to singelton instance, its initialized only once-on the first call to this function */
     static WSLogger* instance = nullptr;
 
     if (!instance) {
@@ -20,6 +21,11 @@ WSLogger& WSLogger::get_instance(const char* server_address, uint16_t port, uint
     }
 
     return *instance;
+}
+
+WSLogger& WSLogger::get_instance()
+{
+    return get_instance("dummy", 0, 0); //dummy args will be ignored since instance is already initialized
 }
 
 WSLogger::WSLogger(const char* server_address, uint16_t port, uint16_t id)


### PR DESCRIPTION
"Singelton Pattern", um eine globale Logging Instanz zu haben die man Programmweit einfach zugreifen kann:

`WS_LOG("WSLogger initialized for Anchor with ID: %d", 0xAFFE);`

Voraussetzung dafür ist, dass der Logger einmal in der main oder irgendwo in einer haupt-routine initialisiert wird:
`WSLogger::get_instance("192.168.0.100", 5000, 0xAFFE);`
